### PR TITLE
changed `DataFrame.append` with equivalent `pd.concat`

### DIFF
--- a/denstatbank/denstatbank.py
+++ b/denstatbank/denstatbank.py
@@ -189,7 +189,7 @@ class StatBankClient:
                         df['variable'] = d['text']
                     else:
                         df['variable'] = d['id']
-                    var_df = var_df.append(df)
+                    var_df = pd.concat([var_df, df])
                 return var_df
             else:
                 return resp


### PR DESCRIPTION
Replacing the [deprecated](https://pandas.pydata.org/pandas-docs/version/1.4/whatsnew/v1.4.0.html#whatsnew-140-deprecations-frame-series-append) `DataFrame.append` with an equivalent call to `pd.concat`. Closes #10 